### PR TITLE
Update SDK versions in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        sdk: [v2.5.0,v2.7.0,v2.8.0,v2.9.0,v3.0.0]
+        sdk: [v2.5.0,v2.7.0,v2.8.0,v2.9.0,v3.0.0,v3.0.2,v3.1.0,v3.1.1,v3.2.0,v3.2.4]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Add latest NCS versions v3.1/v3.2.
Also add the last patch version of each of the latest minor versions.